### PR TITLE
Repro CJS dev -> prod inconsistency

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -7,7 +7,20 @@
     <title>Vite App</title>
   </head>
   <body>
-    <div id="root"></div>
+    <p>
+      The following div will display an error message in dev, where the package
+      imports as undefined, and uppercased text in prod.
+    </p>
+    <div id="import-default"></div>
+    <p>
+      A real-world repro that shows different behavior:
+      <code>react-datetime</code> imports as a function in dev, but as an object
+      with a <code>default</code> property in production.
+    </p>
+    <div>
+      Type of <code>react-datetime</code> is
+      <span id="react-datetime-type"></span>
+    </div>
     <script type="module" src="/main.mjs"></script>
   </body>
 </html>

--- a/app/main.mjs
+++ b/app/main.mjs
@@ -1,3 +1,9 @@
-import { default as esmPackage, cjs as cjsPackage } from "esm-package";
+import upper from "cjs-package";
+import Datetime from "react-datetime";
 
-document.body.textContent = JSON.stringify({ esmPackage, cjsPackage });
+document.querySelector("#import-default").textContent =
+  typeof upper === "function"
+    ? upper("The quick brown fox jumped over the lazy dog")
+    : `Tried to use upper(), but it was type ${typeof upper}`;
+
+document.querySelector("#react-datetime-type").textContent = typeof Datetime;

--- a/app/package.json
+++ b/app/package.json
@@ -9,7 +9,9 @@
   },
   "dependencies": {
     "esm-package": "link:../node_modules/esm-package",
+    "moment": "^2.29.1",
     "react": "^17.0.0",
+    "react-datetime": "^3.1.1",
     "react-dom": "^17.0.0"
   },
   "devDependencies": {

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -5,14 +5,18 @@ specifiers:
   '@types/react-dom': ^17.0.0
   '@vitejs/plugin-react': ^1.0.0
   esm-package: link:../node_modules/esm-package
+  moment: ^2.29.1
   react: ^17.0.0
+  react-datetime: ^3.1.1
   react-dom: ^17.0.0
   typescript: ^4.3.2
   vite: ^2.6.4
 
 dependencies:
   esm-package: link:../node_modules/esm-package
+  moment: 2.29.1
   react: 17.0.2
+  react-datetime: 3.1.1_moment@2.29.1+react@17.0.2
   react-dom: 17.0.2_react@17.0.2
 
 devDependencies:
@@ -659,6 +663,10 @@ packages:
     resolution: {integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==}
     dev: true
 
+  /moment/2.29.1:
+    resolution: {integrity: sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==}
+    dev: false
+
   /ms/2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
@@ -700,6 +708,25 @@ packages:
       source-map-js: 0.6.2
     dev: true
 
+  /prop-types/15.7.2:
+    resolution: {integrity: sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==}
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+    dev: false
+
+  /react-datetime/3.1.1_moment@2.29.1+react@17.0.2:
+    resolution: {integrity: sha512-gHCTjAniCcMb6jdXpz+MpVe/uCeaHNDOofg+l41nLlJI3uBLBMV40CQbGB2TCTUpCzGT1mCs4vQzKGMjXO/WWQ==}
+    peerDependencies:
+      moment: ^2.16.0
+      react: ^16.5.0 || ^17.0.0
+    dependencies:
+      moment: 2.29.1
+      prop-types: 15.7.2
+      react: 17.0.2
+    dev: false
+
   /react-dom/17.0.2_react@17.0.2:
     resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
     peerDependencies:
@@ -709,6 +736,10 @@ packages:
       object-assign: 4.1.1
       react: 17.0.2
       scheduler: 0.20.2
+    dev: false
+
+  /react-is/16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
     dev: false
 
   /react-refresh/0.10.0:

--- a/node_modules/cjs-package/index.js
+++ b/node_modules/cjs-package/index.js
@@ -1,1 +1,4 @@
-module.exports = { cjs: true, json: require("./data.json") };
+module.exports = function(input) {
+  return input.toUpperCase();
+}
+module.exports.__esModule = true;


### PR DESCRIPTION
Shows two different ways that CJS can exhibit different behavior in dev vs. prod (one version where dev gets it wrong and prod gets it right, one that goes the other way).

It seems important that both involve CJS modules that set `module.exports` to a function. From poking around in the debugger I think both issues relate to the `__esModule` flag, but I'm not positive.